### PR TITLE
Notification slider: add extra options

### DIFF
--- a/configpanel/res/values/arrays.xml
+++ b/configpanel/res/values/arrays.xml
@@ -21,6 +21,8 @@
         <item>@string/notification_slider_mode_alarms_only</item>
         <item>@string/notification_slider_mode_priority_only</item>
         <item>@string/notification_slider_mode_none</item>
+        <item>@string/notification_slider_mode_vibrate</item>
+        <item>@string/notification_slider_mode_ring</item>
     </string-array>
 
     <string-array name="notification_slider_action_entry_values" translatable="false">
@@ -28,6 +30,8 @@
         <item>601</item>
         <item>602</item>
         <item>603</item>
+        <item>604</item>
+        <item>605</item>
     </string-array>
 
 </resources>

--- a/configpanel/res/values/strings.xml
+++ b/configpanel/res/values/strings.xml
@@ -85,11 +85,15 @@
     <!-- Notification slider -->
     <string name="notification_slider_category_title">Notification slider</string>
     <string name="notification_slider_selection_dialog_title">Action</string>
+    <string name="notification_slider_ignore_auto_title">Disable during automatic rules</string>
+    <string name="notification_slider_ignore_auto_summary">Ignore the slider when an automatic rule is active</string>
     <string name="notification_slider_top_position">Top position</string>
     <string name="notification_slider_middle_position">Middle position</string>
     <string name="notification_slider_bottom_position">Bottom position</string>
     <string name="notification_slider_mode_total_silence">Total silence</string>
     <string name="notification_slider_mode_alarms_only">Alarms only</string>
     <string name="notification_slider_mode_priority_only">Priority only</string>
-    <string name="notification_slider_mode_none">None</string>
+    <string name="notification_slider_mode_none">All notifications</string>
+    <string name="notification_slider_mode_vibrate">Vibrate</string>
+    <string name="notification_slider_mode_ring">Ring</string>
 </resources>

--- a/configpanel/res/xml/button_panel.xml
+++ b/configpanel/res/xml/button_panel.xml
@@ -24,6 +24,11 @@
     <PreferenceCategory
         android:title="@string/notification_slider_category_title">
 
+        <SwitchPreference
+            android:key="notification_slider_ignore_auto"
+            android:title="@string/notification_slider_ignore_auto_title"
+            android:summary="@string/notification_slider_ignore_auto_summary" />
+
         <ListPreference
             android:key="keycode_top_position"
             android:dialogTitle="@string/notification_slider_selection_dialog_title"

--- a/configpanel/src/com/cyanogenmod/settings/device/ButtonSettings.java
+++ b/configpanel/src/com/cyanogenmod/settings/device/ButtonSettings.java
@@ -17,17 +17,46 @@
 package com.cyanogenmod.settings.device;
 
 import android.os.Bundle;
+import android.os.SystemProperties;
 import android.preference.ListPreference;
 import android.preference.Preference;
+import android.preference.SwitchPreference;
 
 import com.cyanogenmod.settings.device.utils.Constants;
 import com.cyanogenmod.settings.device.utils.FileUtils;
 import com.cyanogenmod.settings.device.utils.NodePreferenceActivity;
 
 public class ButtonSettings extends NodePreferenceActivity {
+    private static final String KEY_IGNORE_AUTO = "notification_slider_ignore_auto";
+    private static final String PROP_IGNORE_AUTO = "persist.op.slider_ignore_auto";
+
+    private SwitchPreference mIgnoreAuto;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.button_panel);
+
+        mIgnoreAuto = (SwitchPreference) findPreference(KEY_IGNORE_AUTO);
+        mIgnoreAuto.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        final String key = preference.getKey();
+        if (KEY_IGNORE_AUTO.equals(key)) {
+            final boolean value = (Boolean) newValue;
+            SystemProperties.set(PROP_IGNORE_AUTO, value ? "true" : "false");
+            return true;
+        }
+
+        return super.onPreferenceChange(preference, newValue);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        mIgnoreAuto.setChecked(SystemProperties.get(PROP_IGNORE_AUTO).equals("true"));
     }
 }

--- a/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
+++ b/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
@@ -32,6 +32,7 @@ import android.hardware.SensorManager;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraAccessException;
+import android.media.AudioManager;
 import android.media.session.MediaSessionLegacyHelper;
 import android.net.Uri;
 import android.os.Handler;
@@ -41,10 +42,12 @@ import android.os.PowerManager.WakeLock;
 import android.os.RemoteException;
 import android.os.ServiceManager;
 import android.os.SystemClock;
+import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.os.Vibrator;
 import android.provider.MediaStore;
 import android.provider.Settings;
+import android.service.notification.ZenModeConfig;
 import android.util.Log;
 import android.util.SparseIntArray;
 import android.view.KeyEvent;
@@ -75,6 +78,10 @@ public class KeyHandler implements DeviceKeyHandler {
     private static final int MODE_ALARMS_ONLY = 601;
     private static final int MODE_PRIORITY_ONLY = 602;
     private static final int MODE_NONE = 603;
+    private static final int MODE_VIBRATE = 604;
+    private static final int MODE_RING = 605;
+
+    private static final String PROP_IGNORE_AUTO = "persist.op.slider_ignore_auto";
 
     private static final int GESTURE_WAKELOCK_DURATION = 3000;
 
@@ -94,11 +101,14 @@ public class KeyHandler implements DeviceKeyHandler {
         sSupportedSliderModes.put(MODE_PRIORITY_ONLY,
                 Settings.Global.ZEN_MODE_IMPORTANT_INTERRUPTIONS);
         sSupportedSliderModes.put(MODE_NONE, Settings.Global.ZEN_MODE_OFF);
+        sSupportedSliderModes.put(MODE_VIBRATE, AudioManager.RINGER_MODE_VIBRATE);
+        sSupportedSliderModes.put(MODE_RING, AudioManager.RINGER_MODE_NORMAL);
     }
 
     private final Context mContext;
     private final PowerManager mPowerManager;
     private KeyguardManager mKeyguardManager;
+    private final AudioManager mAudioManager;
     private final NotificationManager mNotificationManager;
     private EventHandler mEventHandler;
     private SensorManager mSensorManager;
@@ -115,6 +125,7 @@ public class KeyHandler implements DeviceKeyHandler {
     public KeyHandler(Context context) {
         mContext = context;
         mPowerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+        mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
         mNotificationManager
                 = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         mEventHandler = new EventHandler();
@@ -254,8 +265,29 @@ public class KeyHandler implements DeviceKeyHandler {
         }
 
         if (isSliderModeSupported) {
-            mNotificationManager.setZenMode(sSupportedSliderModes.get(scanCode), null, TAG);
-            doHapticFeedback();
+            boolean ignoreAuto = SystemProperties.get(PROP_IGNORE_AUTO).equals("true");
+            boolean isAutoModeActive = false;
+
+            if (ignoreAuto) {
+                ZenModeConfig zmc = mNotificationManager.getZenModeConfig();
+                int len = zmc.automaticRules.size();
+                for (int i = 0; i < len; i++) {
+                    if (zmc.automaticRules.valueAt(i).isAutomaticActive()) {
+                        isAutoModeActive = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!isAutoModeActive) {
+                if (scanCode <= MODE_NONE) {
+                    mNotificationManager.setZenMode(sSupportedSliderModes.get(scanCode), null, TAG);
+                } else {
+                    mAudioManager.setRingerModeInternal(sSupportedSliderModes.get(scanCode));
+                }
+
+                doHapticFeedback();
+            }
         } else if (!mEventHandler.hasMessages(GESTURE_REQUEST)) {
             Message msg = getMessageForKeyEvent(scanCode);
             boolean defaultProximity = mContext.getResources().getBoolean(


### PR DESCRIPTION
- Option to ignore slider in zen auto mode
- Extra notification modes (ring and vibrate)

Signed-off-by: CheckYourScreen <nimitmehta95@gmail.com>

Conflicts:
	keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
[@CheckYourScreen: modified due to grarak's "keyhandler: Move tri state notification" commit]